### PR TITLE
docs: align Cloudflare console deploy flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ wrangler.local.toml
 # Local agent/tool configuration
 .agents/
 .claude/
-.codex/*.local.json
+.codex/
 AGENTS.md
 
 # Logs and operating-system files

--- a/README.md
+++ b/README.md
@@ -196,14 +196,14 @@ npm run deploy
 npx wrangler deploy
 ```
 
-4. 保存并部署。Cloudflare 的 Git 引导流程会根据 `wrangler.toml` 中不带 ID 的声明创建并绑定 `DB` D1 数据库与 `SESSION` KV 命名空间。待部署完成后，进入该 Worker 的 **设置 → 变量和机密**，添加一个类型为**密钥**的变量，变量名填写 `SETUP_TOKEN`，值填写一段足够长且随机的字符串。
+4. 保存并部署。Cloudflare 的 Git 引导流程会根据 `wrangler.toml` 中不带 ID 的声明创建并绑定 `DB` D1 数据库与 `SESSION` KV 命名空间。待部署完成后，进入该 Worker 的 **设置 → 变量和密钥**，添加一个类型为**密钥**的变量，变量名填写 `SETUP_TOKEN`，值填写一段足够长且随机的字符串。
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/lbjxr/CF-Navs/main/docs/screenshots/cf-deploy3.jpg" alt="在 Cloudflare Worker 中添加 SETUP_TOKEN 密钥" width="100%">
 </p>
 
-6. 打开部署后的 Workers URL，并访问 `/install`。输入 `SETUP_TOKEN`，再设置管理员用户名和密码；安装器会初始化数据库 schema 和管理员账号。
-7. 进入该 Worker 的 **域和路由** 页面，关闭两个 Workers URL，然后添加并启用你的自定义域名。
+5. 打开部署后的 Workers URL，并访问 `/install`。输入 `SETUP_TOKEN`，再设置管理员用户名和密码；安装器会初始化数据库 schema 和管理员账号。
+6. 进入该 Worker 的 **域和路由** 页面，关闭两个 Workers URL，然后添加并启用你的自定义域名。
 
 > 如果 `/install` 无法完成 schema 初始化，才使用 D1 SQL Console 手动执行 [schema.sql](schema.sql) 作为恢复手段；不要把手动 SQL 当作正常安装步骤。
 

--- a/docs/guides/DEPLOYMENT.md
+++ b/docs/guides/DEPLOYMENT.md
@@ -15,11 +15,14 @@
 1. 在 GitHub 上 Fork 仓库。
 2. 进入 **Workers & Pages → Create application → Import a repository**，关联 GitHub 并选择 fork。不要使用通用 Deploy Button：它会新建 GitHub 仓库，不能指定已有 Fork。
 3. 生产分支选择 `main`，Build command 填写 `npm run build`，Deploy command 填写 `npx wrangler deploy`。
-4. `wrangler.toml` 只声明 `DB` 和 `SESSION` 绑定，不包含真实资源 ID。Cloudflare Git 引导流程会自动创建并绑定 D1 与 KV 资源。
-5. 在 Variables and Secrets 步骤添加一个加密 Secret：`SETUP_TOKEN`。使用足够长的随机值，不要保存为普通明文变量。
-6. 首次部署完成后，打开站点的 `/install`，输入 `SETUP_TOKEN`，再设置管理员用户名和密码。安装器负责初始化 schema 和管理员账号。
-7. 在 Worker 的 **Settings → Bindings** 中确认 D1 绑定名为 `DB`、KV 绑定名为 `SESSION`。
-8. 确认管理员可以登录后，建议从 **Settings → Variables & Secrets** 删除 `SETUP_TOKEN`，或轮换为新的随机值。`GET /api/install/status` 是公开状态检查，不依赖该 Secret；删除后不影响运行，保留也不会解除永久安装锁。
+4. 保存并部署。Cloudflare 的 Git 引导流程会根据 `wrangler.toml` 中不带 ID 的声明创建并绑定 `DB` D1 数据库与 `SESSION` KV 命名空间。待部署完成后，进入该 Worker 的 **设置 → 变量和密钥**，添加一个类型为**密钥**的变量，变量名填写 `SETUP_TOKEN`，值填写一段足够长且随机的字符串。
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/lbjxr/CF-Navs/main/docs/screenshots/cf-deploy3.jpg" alt="在 Cloudflare Worker 中添加 SETUP_TOKEN 密钥" width="100%">
+</p>
+
+5. 打开部署后的 Workers URL，并访问 `/install`。输入 `SETUP_TOKEN`，再设置管理员用户名和密码；安装器会初始化数据库 schema 和管理员账号。
+6. 进入该 Worker 的 **域和路由** 页面，关闭两个 Workers URL，然后添加并启用你的自定义域名。
 
 > 正常在线安装不需要 Cloudflare API Token、GitHub Actions 或手动 SQL。只有 `/install` 报 schema 初始化错误时，才在 D1 SQL Console 执行一次 [schema.sql](../../schema.sql) 作为恢复步骤。
 
@@ -27,7 +30,7 @@
 
 首次资源创建请从生产分支 `main` 触发。资源创建完成前，建议关闭预览分支自动部署；预览分支可能使用 `wrangler versions upload`，不适合作为首次资源初始化流程。
 
-## 📋 部署前准备
+## 📋 Wrangler CLI 部署前准备
 
 ### 1. Cloudflare 账号
 - [ ] 已注册 Cloudflare 账号
@@ -177,17 +180,14 @@ Cloudflare Git 和 Wrangler CLI 全新安装都先访问 `/install`，输入 `SE
 
 ### 1. 自定义域名
 
-如果你有自己的域名：
+完成 `/install` 后，进入该 Worker 的 **域和路由** 页面：
 
-```bash
-npx wrangler deploy --route "nav.yourdomain.com/*"
-```
+1. 关闭页面中显示的两个 Workers URL。
+2. 添加你的自定义域名并按 Cloudflare 提示完成启用。
 
-或在 Cloudflare Dashboard 中配置 Workers Route。
-
-- [ ] 域名已解析到 Cloudflare
-- [ ] Workers Route 已配置
-- [ ] 自定义域名可访问
+- [ ] 两个 Workers URL 已关闭
+- [ ] 自定义域名已添加并启用
+- [ ] 自定义域名可以正常访问
 
 ### 2. 站点个性化
 

--- a/docs/guides/QUICKSTART.md
+++ b/docs/guides/QUICKSTART.md
@@ -63,33 +63,22 @@ npm run deploy
 
 1. 在 GitHub 上 Fork 本仓库。
 2. 进入 Cloudflare 控制台的 **Workers & Pages → Create application → Import a repository**，关联 GitHub 并选择你的 fork。已有 Fork 不能使用通用 Deploy Button：该按钮会创建新 GitHub 仓库，不能指定现有 Fork。
-3. 生产分支选择 `main`，根目录填写 `/`。
-4. Build command 填写 `npm run build`，Deploy command 填写：
+3. 生产分支选择 `main`，根目录填写 `/`，Build command 填写 `npm run build`，Deploy command 填写：
 
 ```bash
 npx wrangler deploy
 ```
 
-`wrangler.toml` 只声明 `DB` 和 `SESSION` 绑定，不包含真实资源 ID。Cloudflare Git 引导流程会自动创建并绑定 D1 与 KV 资源。
+4. 保存并部署。Cloudflare 的 Git 引导流程会根据 `wrangler.toml` 中不带 ID 的声明创建并绑定 `DB` D1 数据库与 `SESSION` KV 命名空间。待部署完成后，进入该 Worker 的 **设置 → 变量和密钥**，添加一个类型为**密钥**的变量，变量名填写 `SETUP_TOKEN`，值填写一段足够长且随机的字符串。
 
-5. 在 Variables and Secrets 步骤添加一个加密 Secret：
+<p align="center">
+  <img src="https://raw.githubusercontent.com/lbjxr/CF-Navs/main/docs/screenshots/cf-deploy3.jpg" alt="在 Cloudflare Worker 中添加 SETUP_TOKEN 密钥" width="100%">
+</p>
 
-```text
-SETUP_TOKEN = 一段足够长且随机的安装令牌
-```
+5. 打开部署后的 Workers URL，并访问 `/install`。输入 `SETUP_TOKEN`，再设置管理员用户名和密码；安装器会初始化数据库 schema 和管理员账号。
+6. 进入该 Worker 的 **域和路由** 页面，关闭两个 Workers URL，然后添加并启用你的自定义域名。
 
-6. 保存并完成首次部署。
-7. 确认 Worker 的 **Settings → Bindings** 中存在：
-
-| 类型 | 绑定名 | 选择 |
-| --- | --- | --- |
-| D1 database | `DB` | Cloudflare 自动创建的 D1 数据库 |
-| KV namespace | `SESSION` | 你的会话 KV 命名空间 |
-
-8. 访问部署后的 Workers URL，并打开 `/install`。输入 `SETUP_TOKEN`，再设置管理员用户名和密码。安装器会初始化数据库 schema 和管理员账号。
-9. 安装完成并确认管理员可以登录后，可在 **Settings → Variables & Secrets** 删除 `SETUP_TOKEN`，或轮换为新的随机值。公开安装状态检查不依赖它，删除后不影响运行；即使保留，安装器也会永久拒绝再次初始化。正常路径无需 Cloudflare API Token、GitHub Actions 或手动 SQL；只有安装器报 schema 初始化错误时，才在 D1 SQL Console 执行 [schema.sql](../../schema.sql) 进行恢复。
-
-首次部署请从生产分支 `main` 触发。资源创建完成前不要使用预览分支自动部署。
+正常路径无需 Cloudflare API Token、GitHub Actions 或手动 SQL；只有安装器报 schema 初始化错误时，才在 D1 SQL Console 执行 [schema.sql](../../schema.sql) 进行恢复。首次部署请从生产分支 `main` 触发，资源创建完成前不要使用预览分支自动部署。
 
 ## 🔑 首次登录
 
@@ -99,7 +88,7 @@ SETUP_TOKEN = 一段足够长且随机的安装令牌
 2. 输入部署时保存的 `SETUP_TOKEN`
 3. 设置管理员用户名和密码
 4. 安装完成后按页面提示登录
-5. 确认登录成功后，建议从 Worker Secrets 删除或轮换 `SETUP_TOKEN`
+5. 确认登录成功后，建议进入该 Worker 的 **设置 → 变量和密钥** 删除或轮换 `SETUP_TOKEN`
 
 ### 旧数据库升级 / 凭据恢复
 

--- a/docs/guides/TROUBLESHOOTING.md
+++ b/docs/guides/TROUBLESHOOTING.md
@@ -28,8 +28,8 @@ npm run build && npx wrangler deploy
 
 ### `/install` 提示安装令牌无效
 
-1. 确认 Worker 的 **Settings → Variables & Secrets** 中存在加密 Secret `SETUP_TOKEN`，名称大小写完全一致。
-2. 确认输入值没有前后空格，修改 Secret 后重新部署。
+1. 确认 Worker 的 **设置 → 变量和密钥** 中存在类型为**密钥**的变量 `SETUP_TOKEN`，名称大小写完全一致。
+2. 确认输入值没有前后空格；如果修改了密钥，请等待 Cloudflare 保存完成后重新打开 `/install` 检查。
 3. 不要把管理员密码填到 `SETUP_TOKEN`；安装令牌仅用于授权一次安装，管理员密码在 `/install` 页面另行设置。
 4. 如果站点已经安装完成，则不再需要 `SETUP_TOKEN`。`GET /api/install/status` 可公开检查安装状态，删除 Secret 不影响运行；后续安装请求仍会被永久拒绝。
 


### PR DESCRIPTION
## Summary

- align README, quickstart, deployment, and troubleshooting docs with the validated Cloudflare Git deployment flow
- document adding `SETUP_TOKEN` after deployment from **Settings → Variables and Secrets**
- document completing setup at `/install`, then configuring Workers URLs and a custom domain
- fix broken deployment step numbering and replace stale Cloudflare UI labels
- ignore the entire `.codex/` directory so local test credentials, settings backups, and agent assets cannot be committed

## Verification

- `npm test -- --silent`
- 55 test files passed
- 315 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)